### PR TITLE
Fix: documentation link for Thorntail v2

### DIFF
--- a/src/documentation.adoc
+++ b/src/documentation.adoc
@@ -42,7 +42,7 @@ Microservice.
     	  <div class="tab-pane fade in active" id="released">
           <p>The documentation of the latest stable release:<p>
           <ul>
-            <li><a href="/docs/2.0.0.Final">2.0.0.Final Documentation</a></li>
+            <li><a href="/docs/2-0-0-Final">2.0.0.Final Documentation</a></li>
           </ul>
         </div>
         <div class="tab-pane fade in" id="snapshot">


### PR DESCRIPTION
Fix a typo in the documentation link that used to cause a redirection malfunction.

Redirection property was requested as: `"/docs/2.0.0.Final"`

But this property is declared as: 

```
.use(redirect({
'/docs/2-0-0-Final': 'http://docs.wildfly-swarm.io/2.0.0.Final'
}))
```

This property now points correctly to [/docs/2-0-0-Final](http://docs.wildfly-swarm.io/2.0.0.Final)